### PR TITLE
Fix for Windows paths

### DIFF
--- a/lib/server/depend._js
+++ b/lib/server/depend._js
@@ -73,6 +73,7 @@ function _normalize(path) {
 }
 
 function _combine(_, root, path, rel) {
+	root = _normalize(root); // for Windows
 	if (path) {
 		var cut = path.lastIndexOf('/');
 		if (cut <= 0) throw new Error("too many parent dirs: " + rel);


### PR DESCRIPTION
Was getting this error prior to fix.

``` sh
cannot resolve module: syracuse-main/html/main
Error: cannot resolve module: syracuse-main/html/main
  at Object._combine [as resolve] (c:\dev\Syracuse\node_modules\streamline-require\lib\server\depend._js:90:8)
  at c:\dev\Syracuse\node_modules\streamline-require\lib\server\require._js:78:19
  at disp (c:\dev\Syracuse\lib\node_modules\syracuse-main\lib\syracuse._js:1142:3)
  at __streamline$run (c:\dev\Syracuse\node_modules\streamline\lib\fibers-fast\runtime.js:47:14)
```
