### PR TITLE
another fix for windows paths, one level higher

### DIFF
--- a/lib/server/require._js
+++ b/lib/server/require._js
@@ -30,6 +30,10 @@ function _exists(_, fname) {
 	return fs.exists(fname, _);
 }
 
+function _normalize(path) {
+	return path.replace(/\\/g, '/');
+}
+
 // request is a GET on /require/module_path?known=known_modules
 // response is a multipart document containing the requested module script
 // and all its dependencies that are not referenced by any of the known modules.
@@ -41,6 +45,7 @@ exports.dispatcher = function(config) {
 	config = config || {};
 	// default root is lib sibling of ancestor node_modules
 	var root = config.root || path.join(__dirname, "../../../..");
+	root = _normalize(root); // for Windows
 	return function(_, request, response) {
 		function doMultipart(_, etag, parts, readPart) {
 			var boundary = (Math.random() + '-' + Math.random()).replace(/\./g, '');


### PR DESCRIPTION
Must normalize the root path a little higher in the stack. Could potentially remove the `_normalize(root)` call from `depend._js#L76` (added in #3), but doesn't hurt to keep it. 
